### PR TITLE
Improved template tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,31 +42,36 @@ $ python manage.py migrate
 
 ## Usage
 
-### Template tags
+### The `editable` tag
 
-Add `editable` tags to your templates. Beware this tag will show the name
-of the text node if there is no corresponding text nodes in the database.
+Add `editable` tags to your templates.
 
 ```html
-<h1>{% editable header %}</h1>
+<h1>{% editable "header" "My Header" %}</h1>
 
 <div class="content">
-    {% editable text_body %}
+    {% editable "text_body" %}
 </div>
 ```
 
-You can also use the `blockeditable` tag that let's you specify a default text
-that will show up if there is no database entry.
+The `editable` tag takes a default text as the second argument.
+If no default text is passed, the name of the text node (i.e. the first argument)
+will be used if there is no corresponding text node in the database.
+
+### The `blockeditable` tag
+
+You can also use the `blockeditable` tag that let's you wrap content to use
+as the default text.
 
 ```html
 <div class="content">
     <h1>
-        {% blockeditable header %}
+        {% blockeditable "header" %}
             Read My Awesome Text
         {% endblockeditable %}
     </h1>
     
-    {% blockeditable content %}
+    {% blockeditable "content" %}
         Put your default text here!
     {% endblockeditable %}
 </div>

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages
 setup(
     name='django-text',
     description='Intuitive text editing for the Django Admin.',
-    version='1.2.6',
+    version='1.3.0',
     long_description=open('README.md').read(),
     author='Anton Agestam',
     author_email='msn@antonagestam.se',

--- a/text/templatetags/editable.py
+++ b/text/templatetags/editable.py
@@ -53,12 +53,13 @@ class BlockTextNode(TextNode):
 @register.tag(name='editable')
 def editable(parser, token):
     bits = token.split_contents()
-    text_name = parser.compile_filter(bits[1])
+    text_name = bits[1]
     try:
         default = bits[2]
-    except ValueError:
+    except IndexError:
         default = text_name
     default = parser.compile_filter(default)
+    text_name = parser.compile_filter(text_name)
     return TextNode(text_name, default)
 
 


### PR DESCRIPTION
`text_name` is now parsed as a filter expression which means it accepts template variables:

``` html
{% with node_name="my_text_node" %}
    {% editable node_name %}
{% endwith %}
```

This means old code needs to be updated to add quotes around the node name:

``` html
{% editable "my_text_node" %}
```

The `editable` tag now accepts a second argument to use as a default text:

``` html
{% editable "my_text_node" "My default text" %}
```
