### PR TITLE
rename `editable` -> `text`, `blockeditable` -> `blocktext`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,45 +80,49 @@ Run ``migrate``.
 Usage
 -----
 
-The ``editable`` tag
-~~~~~~~~~~~~~~~~~~~~
+The ``text`` tag
+~~~~~~~~~~~~~~~~
 
 Add ``editable`` tags to your templates.
 
 .. code:: html
 
-    <h1>{% editable "header" "My Header" %}</h1>
+    {% load text %}
+
+    <h1>{% text "header" "My Header" %}</h1>
 
     <div class="content">
-        {% editable "text_body" %}
+        {% text "text_body" %}
     </div>
 
-The ``editable`` tag takes a default text as the second argument. If no
+The ``text`` tag takes a default text as the second argument. If no
 default text is passed, the name of the text node (i.e. the first
 argument) will be used if there is no corresponding text node in the
 database.
 
-The ``blockeditable`` tag
-~~~~~~~~~~~~~~~~~~~~~~~~~
+The ``blocktext`` tag
+~~~~~~~~~~~~~~~~~~~~~
 
-You can also use the ``blockeditable`` tag that let's you wrap content
+You can also use the ``blocktext`` tag that let's you wrap content
 to use as the default text.
 
 .. code:: html
 
+    {% load text %}
+
     <div class="content">
         <h1>
-            {% blockeditable "header" %}
+            {% blocktext "header" %}
                 Read My Awesome Text
-            {% endblockeditable %}
+            {% endblocktext %}
         </h1>
         
-        {% blockeditable "content" %}
+        {% blocktext "content" %}
             Put your default text here!
-        {% endblockeditable %}
+        {% endblocktext %}
     </div>
 
-The ``blockeditable`` tags works with translation tags inside of it. So
+The ``blocktext`` tags works with translation tags inside of it. So
 if you already have a translated site, you can wrap your content with
 this tag and only add text nodes for some of the languages that you
 support.
@@ -126,20 +130,21 @@ support.
 Specifying content type
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Both the ``editable`` and the ``blockeditable`` tags support specifying
-the content type of its default text.
+Both the ``text`` and the ``blocktext`` tags support specifying
+the content type of its default text. The choices are `"html"`,
+`"markdown"` and `"text"` which is the default.
 
 .. code:: html
 
-    {% editable "html_node" "<h1>Hello World!</h1>" "html" %}
+    {% text "html_node" "<h1>Hello World!</h1>" "html" %}
 
-    {% blockeditable "markdown_node" "markdown" %}
+    {% blocktext "markdown_node" "markdown" %}
     # Hello there,
 
     I can have markdown in my templates!
-    {% endblockeditable %}
+    {% endblocktext %}
 
-If this is not provided both will default to raw text.
+If content type is not provided both will default to text.
 
 Content editing
 ~~~~~~~~~~~~~~~

--- a/text/__init__.py
+++ b/text/__init__.py
@@ -1,2 +1,2 @@
-VERSION = (1, 5, 6)
+VERSION = (1, 6, 0)
 __version__ = '.'.join((str(i) for i in VERSION))

--- a/text/templatetags/text.py
+++ b/text/templatetags/text.py
@@ -1,7 +1,7 @@
 from django import template
 
-from text.models import Text
-from text.conf import settings
+from ..models import Text
+from ..conf import settings
 
 register = template.Library()
 
@@ -69,8 +69,8 @@ class BlockTextNode(TextNode):
         return self.get_placeholder(context)
 
 
-@register.tag(name='editable')
-def editable(parser, token):
+@register.tag(name='text')
+def text(parser, token):
     bits = token.split_contents()
     text_name = bits[1]
     try:
@@ -85,9 +85,9 @@ def editable(parser, token):
     return TextNode(text_name, default, text_type)
 
 
-@register.tag(name='blockeditable')
-def blockeditable(parser, token):
-    nodelist = parser.parse(('endblockeditable', ))
+@register.tag(name='blocktext')
+def blocktext(parser, token):
+    nodelist = parser.parse(('endblocktext', ))
     parser.delete_first_token()
     bits = token.split_contents()
     text_name = parser.compile_filter(bits[1])

--- a/text/tests/test_middleware.py
+++ b/text/tests/test_middleware.py
@@ -8,7 +8,7 @@ from mock import patch
 from text.middleware import build_context, create_text, TextMiddleware
 from text.models import Text
 from text.conf import settings
-from text.templatetags.editable import TextNode
+from text.templatetags.text import TextNode
 
 
 class TestBuildContext(TestCase):

--- a/text/tests/test_templatetags.py
+++ b/text/tests/test_templatetags.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 from django.template import FilterExpression, Parser
 from django.http import HttpRequest
 
-from text.templatetags.editable import TextNode
+from text.templatetags.text import TextNode
 from text.conf import settings
 
 


### PR DESCRIPTION
closes #45 
