### PR TITLE
Support for Django 1.8 and 1.9 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: python
+python:
+  - "2.7"
+  - "3.4"
+  - "3.5"
+env:
+  - DJANGO_VERSION=1.8
+  - DJANGO_VERSION=1.9
+install:
+  - pip install -r test-requirements.txt
+  - pip install -q Django==$DJANGO_VERSION
+script: make test-coverage
+after_success: make test-coveralls
+notifications:
+  email: false

--- a/LICENSE
+++ b/LICENSE
@@ -53,3 +53,61 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+Includes simpleblocktag. Copied from license file:
+--------------------------------------------------
+
+The MIT License (MIT)
+
+Copyright (c) 2013 Ilya Tikhonov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+Includes `parse_bits` from Django 1.8. Copied from license file:
+----------------------------------------------------------------
+
+Copyright (c) Django Software Foundation and individual contributors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice,
+       this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+
+    3. Neither the name of Django nor the names of its contributors may be used
+       to endorse or promote products derived from this software without
+       specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+test:
+	python runtests.py
+
+test-coverage:
+	coverage run runtests.py
+
+test-coveralls:
+	coveralls

--- a/README.rst
+++ b/README.rst
@@ -146,6 +146,28 @@ the content type of its default text. The choices are `"html"`,
 
 If content type is not provided both will default to text.
 
+Disable instant updating
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default the templatetags will wrap all text nodes with a span
+element to enable "instant updating", if
+``TEXT_TOOLBAR_INSTANT_UPDATE`` is set to ``True``. Sometimes this
+can cause trouble, for instance when you want to have editable
+texts inside ``<title>`` or ``<meta>`` elements.
+
+You can disable instant updating on per-node basis by setting the
+templatetag keyword argument ``instant_update`` to  ``False``:
+
+.. code:: html
+
+    <title>{% text "title" "Welcome!" instant_update=False %}</title>
+    
+    <title>
+        {% blocktext "block_title" instant_update=False %}
+        Welcome one, welcome all!
+        {% endblocktext %}
+    </title>
+
 Content editing
 ~~~~~~~~~~~~~~~
 
@@ -225,13 +247,13 @@ Run tests.
 
 .. code:: shell
 
-    $ export PYTHONPATH=`pwd`; runtests.py --settings='text.tests.settings'
+    $ make test
 
 Run tests with coverage.
 
 .. code:: shell
 
-    $ export PYTHONPATH=`pwd`; coverage run `which runtests.py` --settings='text.tests.settings'
+    $ make test-coverage
 
 
 License

--- a/circle.yml
+++ b/circle.yml
@@ -1,9 +1,0 @@
-machine:
-  python:
-    version: 2.7.5
-test:
-  override:
-    - export PYTHONPATH=`pwd`; coverage run `which runtests.py` --settings='text.tests.settings'; coveralls
-dependencies:
-  override:
-    - pip install -r test-requirements.txt; pip install coveralls

--- a/runtests.py
+++ b/runtests.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os, sys
+from django.conf import settings
+from django import setup
+
+settings.configure(**{
+    'DEBUG': True,
+    'TEMPLATE_DEBUG': True,
+    'DATABASES': {
+        'default': {
+            'ENGINE': 'django.db.backends.sqlite3',
+            'NAME': ':memory:'
+        }
+    },
+    'INSTALLED_APPS': ('text', ),
+    'TEMPLATE_DIRS': (
+        os.path.join(os.path.dirname(__file__), 'text', 'templates'),
+    ),
+    'TEMPLATE_CONTEXT_PROCESSORS': (
+        'django.contrib.auth.context_processors.auth',
+        'django.core.context_processors.request',
+    ),
+    'MIDDLEWARE_CLASSES': (
+        'text.middleware.TextMiddleware',
+        'text.middleware.ToolbarMiddleware',
+    ),
+    'ROOT_URLCONF': 'text.urls',
+})
+
+try:
+    # Django <= 1.8
+    from django.test.simple import DjangoTestSuiteRunner
+    test_runner = DjangoTestSuiteRunner(verbosity=1)
+except ImportError:
+    # Django >= 1.8
+    from django.test.runner import DiscoverRunner
+    test_runner = DiscoverRunner(verbosity=1)
+
+if __name__ == "__main__":
+    setup()
+    failures = test_runner.run_tests(['text'])
+    if failures:
+        sys.exit(failures)

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     license='The MIT License (MIT)',
     include_package_data=True,
     zip_safe=False,  # because we're including static files
-    install_requires=['Django>=1.7.4', 'Markdown>=2.6', ],
+    install_requires=['Django>=1.7.4', 'Markdown>=2.6'],
     classifiers=['Programming Language :: Python :: 2.7',
                  'Programming Language :: Python :: 3']
 )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,4 @@
-click==3.3
-Django==1.7.5
-django-pluggable==0.0.1
+Django>=1.9
 Markdown==2.6.1
 mock==1.0.1
 coverage==3.7.1

--- a/text/migrations/0007_type_int_to_char.py
+++ b/text/migrations/0007_type_int_to_char.py
@@ -5,7 +5,7 @@ from django.db import migrations
 
 
 def populate_type_char(apps, schema_editor):
-    Text = apps.get_model(b'text', b'Text')
+    Text = apps.get_model('text', 'Text')
     types = {
         0: b'text',
         1: b'markdown',

--- a/text/templatetags/text.py
+++ b/text/templatetags/text.py
@@ -1,99 +1,57 @@
 from django import template
 
-from ..models import Text
+from ..vendor.simple_block_tag import simple_block_tag
 from ..conf import settings
 
 register = template.Library()
 
 
-class TextNode(template.Node):
-    def __init__(self, text_name, default_text='', text_type=Text.TYPE_TEXT):
-        self.text_name = text_name
-        if not isinstance(default_text, template.FilterExpression):
-            default_text = template.FilterExpression(default_text, template.Parser([]))
-        if default_text.token.replace('"', '').replace("'", '') == '' or not default_text:
-            default_text = text_name
-        self.default_text = default_text
-        self.type = text_type
-        if not isinstance(self.type, template.FilterExpression):
-            self.type = template.FilterExpression(self.type, template.Parser([]))
-
-    def resolved_text_name(self, context):
-        text_name = self.text_name.resolve(context)
-        if not text_name or text_name.strip() == '':
-            raise template.TemplateSyntaxError("Invalid text node name")
-        return text_name
-
-    def set_default(self, text_name, context, content):
-        if not hasattr(context['request'], 'text_default_register'):
-            context['request'].text_default_register = {}
-        context['request'].text_default_register[text_name] = content.strip()
-
-    def set_type(self, text_name, context, text_type):
-        if not hasattr(context['request'], 'text_type_register'):
-            context['request'].text_type_register = {}
-        context['request'].text_type_register[text_name] = text_type
-
-    def register(self, text_name, context):
-        if not hasattr(context['request'], 'text_register'):
-            context['request'].text_register = []
-        context['request'].text_register.append(text_name)
-
-    def get_placeholder(self, context):
-        placeholder = "{{ text_placeholder_%s }}"
-        text_name = self.resolved_text_name(context)
-        if settings.TOOLBAR_INSTANT_UPDATE:
-            before, after = settings.INLINE_WRAPPER
-            before = before.format(text_name, settings.INLINE_WRAPPER_CLASS)
-            placeholder = ''.join((before, placeholder, after))
-        return placeholder % text_name
-
-    def render(self, context):
-        text_name = self.resolved_text_name(context)
-        self.register(text_name, context)
-        self.set_default(text_name, context, self.default_text.resolve(context))
-        self.set_type(text_name, context, self.type.resolve(context))
-        return self.get_placeholder(context)
+def get_placeholder(node_name, context, instant_update):
+    placeholder = "{{ text_placeholder_%s }}"
+    if instant_update and settings.TOOLBAR_INSTANT_UPDATE:
+        before, after = settings.INLINE_WRAPPER
+        before = before.format(node_name, settings.INLINE_WRAPPER_CLASS)
+        placeholder = ''.join((before, placeholder, after))
+    return placeholder % node_name
 
 
-class BlockTextNode(TextNode):
-    def __init__(self, nodelist, *args, **kwargs):
-        super(BlockTextNode, self).__init__(*args, **kwargs)
-        self.nodelist = nodelist
-
-    def render(self, context):
-        text_name = self.resolved_text_name(context)
-        self.register(text_name, context)
-        self.set_default(text_name, context, self.nodelist.render(context))
-        self.set_type(text_name, context, self.type.resolve(context))
-        return self.get_placeholder(context)
+def set_default(node_name, context, content):
+    if not hasattr(context['request'], 'text_default_register'):
+        context['request'].text_default_register = {}
+    context['request'].text_default_register[node_name] = content.strip()
 
 
-@register.tag(name='text')
-def text(parser, token):
-    bits = token.split_contents()
-    text_name = bits[1]
-    try:
-        default = bits[2]
-        text_type = bits[3]
-    except IndexError:
-        default = text_name
-        text_type = Text.TYPE_TEXT
-    default = parser.compile_filter(default)
-    text_name = parser.compile_filter(text_name)
-    text_type = parser.compile_filter(text_type)
-    return TextNode(text_name, default, text_type)
+def set_type(node_name, context, text_type):
+    if not hasattr(context['request'], 'text_type_register'):
+        context['request'].text_type_register = {}
+    context['request'].text_type_register[node_name] = text_type
 
 
-@register.tag(name='blocktext')
-def blocktext(parser, token):
-    nodelist = parser.parse(('endblocktext', ))
-    parser.delete_first_token()
-    bits = token.split_contents()
-    text_name = parser.compile_filter(bits[1])
-    try:
-        text_type = bits[2]
-    except IndexError:
-        text_type = Text.TYPE_TEXT
-    text_type = parser.compile_filter(text_type)
-    return BlockTextNode(nodelist, text_name, text_type=text_type)
+def register_node(node_name, context):
+    if not hasattr(context['request'], 'text_register'):
+        context['request'].text_register = []
+    context['request'].text_register.append(node_name)
+
+
+@register.simple_tag(name='text', takes_context=True)
+def text(context, node_name, default_text, node_type='text', instant_update=True):
+    """
+    Syntax:
+        {% text <node_name> <default_text> <node_type> %}
+    """
+    register_node(node_name, context)
+    set_default(node_name, context, default_text)
+    set_type(node_name, context, node_type)
+    return get_placeholder(node_name, context, instant_update)
+
+
+@simple_block_tag(register, name='blocktext', takes_context=True)
+def blocktext(context, content, node_name, node_type='html', instant_update=True):
+    """
+    Syntax:
+        {% blocktext <node_name> <node_type> %}<default_text>{% endblocktext %}
+    """
+    register_node(node_name, context)
+    set_default(node_name, context, content)
+    set_type(node_name, context, node_type)
+    return get_placeholder(node_name, context, instant_update)

--- a/text/tests/test_templatetags.py
+++ b/text/tests/test_templatetags.py
@@ -1,62 +1,112 @@
 from django.test import TestCase
-from django.template import FilterExpression, Parser
 from django.http import HttpRequest
+from django.template import Template, Context
 
-from text.templatetags.text import TextNode
+from text.templatetags.text import set_default, set_type, register_node, get_placeholder
 from text.conf import settings
 
 
-class TestTextNode(TestCase):
-    def fe(self, name):
-        fe = FilterExpression('"{0}"'.format(name), Parser([]))
-        return fe
+load_statement = "{% load text %}"
 
+def get_context():
+        return Context({'request': HttpRequest()})
+
+class TestTextTag(TestCase):
+    def test_variable(self):
+        settings.TOOLBAR_INSTANT_UPDATE = False
+        context = get_context()
+        node_name = 'a_node'
+        default_text = 'some default content :)'
+        node_type = "html"
+        template = Template(load_statement + """\
+{%% with t="%s" %%}{%% text "%s" t "%s" %%}{%% endwith %%}""" % (default_text, node_name, node_type))
+        output = template.render(context)
+        self.assertEqual(output, '{{ text_placeholder_%s }}' % node_name)
+        self.assertEqual(context['request'].text_default_register[node_name], default_text)
+        self.assertEqual(context['request'].text_type_register[node_name], node_type)
+        self.assertIn(node_name, context['request'].text_register)
+
+    def test_without_node_type(self):
+        settings.TOOLBAR_INSTANT_UPDATE = False
+        context = get_context()
+        node_name = 'a_node'
+        default_text = 'this is my default text'
+        template = Template(load_statement + '{%% text "%s" "%s" %%}' % (node_name, default_text))
+        output = template.render(context)
+        self.assertEqual(output, '{{ text_placeholder_%s }}' % node_name)
+        self.assertEqual(context['request'].text_default_register[node_name], default_text)
+        self.assertEqual(context['request'].text_type_register[node_name], "text")
+        self.assertIn(node_name, context['request'].text_register)
+
+
+class TestBlockTextTag(TestCase):
+    def test_without_node_type(self):
+        settings.TOOLBAR_INSTANT_UPDATE = False
+        context = get_context()
+        node_name = 'a_node'
+        default_text = '<b>some</b> default content :)'
+        node_type = "html"
+        template = Template(load_statement + """\
+{%% blocktext "%s" %%}%s{%% endblocktext %%}""" % (node_name, default_text))
+        output = template.render(context)
+        self.assertEqual(output, '{{ text_placeholder_%s }}' % node_name)
+        self.assertEqual(context['request'].text_default_register[node_name], default_text)
+        self.assertEqual(context['request'].text_type_register[node_name], node_type)
+        self.assertIn(node_name, context['request'].text_register)
+
+    def test_with_node_type(self):
+        settings.TOOLBAR_INSTANT_UPDATE = True
+        context = get_context()
+        node_name = 'a_node'
+        default_text = '<b>some</b> default content :)'
+        node_type = "text"
+        template = Template(load_statement + """\
+{%% blocktext "%s" node_type="%s" instant_update=False %%}%s{%% endblocktext %%}""" % (
+            node_name, node_type, default_text))
+        output = template.render(context)
+        self.assertEqual(output, '{{ text_placeholder_%s }}' % node_name)
+        self.assertEqual(context['request'].text_default_register[node_name], default_text)
+        self.assertEqual(context['request'].text_type_register[node_name], node_type)
+        self.assertIn(node_name, context['request'].text_register)
+
+
+class TestGetPlaceholder(TestCase):
     def test_get_wrapped_placeholder(self):
         name = 'name_of_text_node'
-        fe = self.fe(name)
         settings.TOOLBAR_INSTANT_UPDATE = True
-        placeholder = TextNode(fe).get_placeholder({})
+        placeholder = get_placeholder(name, {}, True)
         expected = '<span data-text-name="name_of_text_node" class="dj_text_inline_wrapper">{{ text_placeholder_name_of_text_node }}</span>'
         self.assertEqual(placeholder, expected)
 
     def test_get_placeholder(self):
         name = 'name_of_text_node'
-        fe = self.fe(name)
         settings.TOOLBAR_INSTANT_UPDATE = False
-        placeholder = TextNode(fe).get_placeholder({})
+        placeholder = get_placeholder(name, {}, True)
         expected = '{{ text_placeholder_name_of_text_node }}'
         self.assertEqual(placeholder, expected)
 
+
+class TestSetDefault(TestCase):
     def test_set_default(self):
         name = 'name_of_text_node'
         content = 'test node content'
         context = {'request': HttpRequest()}
-        fe = self.fe(name)
-        t = TextNode(fe)
-        t.set_default(name, context, content)
+        set_default(name, context, content)
         self.assertEqual(context['request'].text_default_register[name], content)
 
+
+class TestSetType(TestCase):
     def test_set_type(self):
         name = 'name_of_text_node'
-        type = 'html'
+        node_type = 'html'
         context = {'request': HttpRequest()}
-        fe = self.fe(name)
-        t = TextNode(fe)
-        t.set_type(name, context, type)
-        self.assertEqual(context['request'].text_type_register[name], type)
+        set_type(name, context, node_type)
+        self.assertEqual(context['request'].text_type_register[name], node_type)
 
+
+class TestRegister(TestCase):
     def test_register(self):
         name = 'name_of_text_node'
         context = {'request': HttpRequest()}
-        fe = self.fe(name)
-        t = TextNode(fe)
-        t.register(name, context)
+        register_node(name, context)
         self.assertIn(name, context['request'].text_register)
-
-    def test_init_logic(self):
-        name = self.fe('name_of_text_node')
-        t = TextNode(name)
-        self.assertEqual(t.text_name, t.default_text)
-        default_text = self.fe('hejhej!')
-        t = TextNode(name, default_text)
-        self.assertEqual(t.default_text, default_text)

--- a/text/vendor/__init__.py
+++ b/text/vendor/__init__.py
@@ -1,0 +1,1 @@
+__author__ = 'antonagestam'

--- a/text/vendor/parse_bits.py
+++ b/text/vendor/parse_bits.py
@@ -1,0 +1,101 @@
+"""
+`parse_bits` is copied from Django 1.8 `django.template.base.parse_bits`.
+
+Copyright (c) Django Software Foundation and individual contributors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice,
+       this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+
+    3. Neither the name of Django nor the names of its contributors may be used
+       to endorse or promote products derived from this software without
+       specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""
+
+from django.template.base import TemplateSyntaxError, token_kwargs
+from django.utils import six
+
+def parse_bits(parser, bits, params, varargs, varkw, defaults,
+               takes_context, name):
+    """
+    Parses bits for template tag helpers (simple_tag, include_tag and
+    assignment_tag), in particular by detecting syntax errors and by
+    extracting positional and keyword arguments.
+    """
+    if takes_context:
+        if params[0] == 'context':
+            params = params[1:]
+        else:
+            raise TemplateSyntaxError(
+                "'%s' is decorated with takes_context=True so it must "
+                "have a first argument of 'context'" % name)
+    args = []
+    kwargs = {}
+    unhandled_params = list(params)
+    for bit in bits:
+        # First we try to extract a potential kwarg from the bit
+        kwarg = token_kwargs([bit], parser)
+        if kwarg:
+            # The kwarg was successfully extracted
+            param, value = list(six.iteritems(kwarg))[0]
+            if param not in params and varkw is None:
+                # An unexpected keyword argument was supplied
+                raise TemplateSyntaxError(
+                    "'%s' received unexpected keyword argument '%s'" %
+                    (name, param))
+            elif param in kwargs:
+                # The keyword argument has already been supplied once
+                raise TemplateSyntaxError(
+                    "'%s' received multiple values for keyword argument '%s'" %
+                    (name, param))
+            else:
+                # All good, record the keyword argument
+                kwargs[str(param)] = value
+                if param in unhandled_params:
+                    # If using the keyword syntax for a positional arg, then
+                    # consume it.
+                    unhandled_params.remove(param)
+        else:
+            if kwargs:
+                raise TemplateSyntaxError(
+                    "'%s' received some positional argument(s) after some "
+                    "keyword argument(s)" % name)
+            else:
+                # Record the positional argument
+                args.append(parser.compile_filter(bit))
+                try:
+                    # Consume from the list of expected positional arguments
+                    unhandled_params.pop(0)
+                except IndexError:
+                    if varargs is None:
+                        raise TemplateSyntaxError(
+                            "'%s' received too many positional arguments" %
+                            name)
+    if defaults is not None:
+        # Consider the last n params handled, where n is the
+        # number of defaults.
+        unhandled_params = unhandled_params[:-len(defaults)]
+    if unhandled_params:
+        # Some positional arguments were not supplied
+        raise TemplateSyntaxError(
+            "'%s' did not receive value(s) for the argument(s): %s" %
+            (name, ", ".join("'%s'" % p for p in unhandled_params)))
+    return args, kwargs

--- a/text/vendor/simple_block_tag.py
+++ b/text/vendor/simple_block_tag.py
@@ -1,0 +1,81 @@
+"""
+https://github.com/piha/django-simple-block-tag
+
+The MIT License (MIT)
+
+Copyright (c) 2013 Ilya Tikhonov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+from django.template.base import Node
+
+from inspect import getargspec
+from functools import partial
+
+from .parse_bits import parse_bits
+
+
+def simple_block_tag(register, takes_context=None, name=None):
+    def dec(func):
+        params, varargs, varkw, defaults = getargspec(func)
+
+        class SimpleNode(Node):
+            def __init__(self, nodelist, takes_context, args, kwargs):
+                self.nodelist = nodelist
+                self.takes_context = takes_context
+                self.args = args
+                self.kwargs = kwargs
+
+            def get_resolved_arguments(self, context):
+                resolved_args = [var.resolve(context) for var in self.args]
+                resolved_args = [self.nodelist.render(context)] + resolved_args
+                if self.takes_context:
+                    resolved_args = [context] + resolved_args
+                resolved_kwargs = dict((k, v.resolve(context))
+                                       for k, v in self.kwargs.items())
+                return resolved_args, resolved_kwargs
+
+            def render(self, context):
+                resolved_args, resolved_kwargs = self.get_resolved_arguments(context)
+                return func(*resolved_args, **resolved_kwargs)
+
+        def tag_compiler(parser, token, params, varargs, varkw, defaults,
+                         name, takes_context, function_name):
+            bits = token.split_contents()[1:]
+            bits = [''] + bits  # add placeholder for content arg
+            args, kwargs = parse_bits(parser, bits, params, varargs, varkw,
+                                      defaults, takes_context, name)
+            args = args[1:]  # remove content placeholder
+            nodelist = parser.parse(('end{}'.format(function_name),))
+            parser.delete_first_token()
+            return SimpleNode(nodelist, takes_context, args, kwargs)
+
+        function_name = (name or
+                         getattr(func, '_decorated_function', func).__name__)
+        compile_func = partial(tag_compiler,
+                               params=params, varargs=varargs, varkw=varkw,
+                               defaults=defaults, name=function_name,
+                               takes_context=takes_context, function_name=function_name)
+        compile_func.__doc__ = func.__doc__
+
+        register.tag(function_name, compile_func)
+        return func
+
+    return dec

--- a/text/widgets.py
+++ b/text/widgets.py
@@ -1,15 +1,11 @@
+from __future__ import unicode_literals
+
 from django import forms
 from django.utils.html import format_html
 from django.forms.utils import flatatt
 from django.utils.encoding import force_text
 
 from text.models import Text
-
-
-MARKDOWN_TEMPLATE = u"""
-<textarea{0}>\r\n{1}</textarea>
-<div class="djtext_html_editor">{2}</div>
-"""
 
 
 class HTMLEditorWidget(forms.widgets.Textarea):
@@ -40,7 +36,7 @@ class HTMLEditorWidget(forms.widgets.Textarea):
         t = Text(type=Text.TYPE_HTML, body=value)
         rendered = t.render()
         return format_html(
-            MARKDOWN_TEMPLATE,
+            '<textarea{0}>\r\n{1}</textarea><div class="djtext_html_editor">{2}</div>',
             flatatt(final_attrs),
             force_text(value),
             rendered)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,5 @@
+[tox]
+envlist = py26,py27
+[testenv]
+deps=-rtest-requirements.txt
+commands=py.test


### PR DESCRIPTION
 This is a big rewrite for support of Django 1.8 and 1.9. (squash of #47)

With this release support for Django 1.7 and Python 3.2 and 3.3 is dropped, as they are no longer supported by Django.

Also introduces the `instant_update` templatetag keyword argument to fix #37.
