### PR TITLE
Templatetags syntax check and tests

### DIFF
--- a/text/templatetags/text.py
+++ b/text/templatetags/text.py
@@ -1,5 +1,5 @@
 from django import template
-from django.utils.safestring import SafeString
+from django.utils.safestring import SafeData
 
 from ..vendor.simple_block_tag import simple_block_tag
 from ..conf import settings
@@ -41,7 +41,7 @@ def valid_type(type):
 
 
 def is_safestring(var):
-    return isinstance(var, SafeString)
+    return isinstance(var, SafeData)
 
 
 @register.simple_tag(name='text', takes_context=True)

--- a/text/templatetags/text.py
+++ b/text/templatetags/text.py
@@ -1,9 +1,12 @@
 from django import template
+from django.utils.safestring import SafeString
 
 from ..vendor.simple_block_tag import simple_block_tag
 from ..conf import settings
+from ..models import Text
 
 register = template.Library()
+TEXT_TYPES = [t[0] for t in Text.TYPES]
 
 
 def get_placeholder(node_name, context, instant_update):
@@ -33,25 +36,41 @@ def register_node(node_name, context):
     context['request'].text_register.append(node_name)
 
 
+def valid_type(type):
+    return type in TEXT_TYPES
+
+
+def is_safestring(var):
+    return isinstance(var, SafeString)
+
+
 @register.simple_tag(name='text', takes_context=True)
 def text(context, node_name, default_text, node_type='text', instant_update=True):
     """
     Syntax:
-        {% text <node_name> <default_text> <node_type> %}
+        {% text <node_name> <default_text> <node_type> <instant_update> %}
     """
+    if not is_safestring(node_name) or not is_safestring(default_text):
+        raise template.TemplateSyntaxError("`node_name` and `default_text` need to be quoted strings")
+    if not valid_type(node_type):
+        raise template.TemplateSyntaxError("`node_type` has to be one of %s" % (', '.join(TEXT_TYPES)))
     register_node(node_name, context)
     set_default(node_name, context, default_text)
     set_type(node_name, context, node_type)
-    return get_placeholder(node_name, context, instant_update)
+    return get_placeholder(node_name, context, bool(instant_update))
 
 
 @simple_block_tag(register, name='blocktext', takes_context=True)
 def blocktext(context, content, node_name, node_type='html', instant_update=True):
     """
     Syntax:
-        {% blocktext <node_name> <node_type> %}<default_text>{% endblocktext %}
+        {% blocktext <node_name> <node_type> <instant_update> %}<default_text>{% endblocktext %}
     """
+    if not is_safestring(node_name):
+        raise template.TemplateSyntaxError("`node_name` need to be a quoted string")
+    if not valid_type(node_type):
+        raise template.TemplateSyntaxError("`node_type` has to be one of %s" % (', '.join(TEXT_TYPES)))
     register_node(node_name, context)
     set_default(node_name, context, content)
     set_type(node_name, context, node_type)
-    return get_placeholder(node_name, context, instant_update)
+    return get_placeholder(node_name, context, bool(instant_update))


### PR DESCRIPTION
Templatetags raise `django.template.TemplateSyntaxError` when passed incorrect or wrong number of arguments.
