### PR TITLE
Fix missing mark_safe 

### DIFF
--- a/text/templatetags/text.py
+++ b/text/templatetags/text.py
@@ -1,5 +1,5 @@
 from django import template
-from django.utils.safestring import SafeData
+from django.utils.safestring import SafeData, mark_safe
 
 from ..vendor.simple_block_tag import simple_block_tag
 from ..conf import settings
@@ -15,7 +15,7 @@ def get_placeholder(node_name, context, instant_update):
         before, after = settings.INLINE_WRAPPER
         before = before.format(node_name, settings.INLINE_WRAPPER_CLASS)
         placeholder = ''.join((before, placeholder, after))
-    return placeholder % node_name
+    return mark_safe(placeholder % node_name)
 
 
 def set_default(node_name, context, content):

--- a/text/tests/test_templatetags.py
+++ b/text/tests/test_templatetags.py
@@ -28,6 +28,23 @@ class TestTextTag(TestCase):
         self.assertEqual(context['request'].text_type_register[node_name], node_type)
         self.assertIn(node_name, context['request'].text_register)
 
+    def test_with_instant_update(self):
+        settings.TOOLBAR_INSTANT_UPDATE = True
+        context = get_context()
+        node_name = 'a_node'
+        default_text = 'some default content :)'
+        node_type = "html"
+        template = Template(load_statement + """\
+{%% with t="%s" %%}{%% text "%s" t "%s" %%}{%% endwith %%}""" % (default_text, node_name, node_type))
+        output = template.render(context)
+        expected = """\
+<span data-text-name="a_node" class="dj_text_inline_wrapper">{{ text_placeholde\
+r_%s }}</span>""" % node_name
+        self.assertEqual(output, expected)
+        self.assertEqual(context['request'].text_default_register[node_name], default_text)
+        self.assertEqual(context['request'].text_type_register[node_name], node_type)
+        self.assertIn(node_name, context['request'].text_register)
+
     def test_without_node_type(self):
         settings.TOOLBAR_INSTANT_UPDATE = False
         context = get_context()


### PR DESCRIPTION
Broken on Django 1.9
