### PR TITLE
increase z-index of toolbar

### DIFF
--- a/text/static/text/css/toolbar.css
+++ b/text/static/text/css/toolbar.css
@@ -17,7 +17,7 @@
     -webkit-box-sizing: border-box;
     -moz-box-sizing: border-box;
     box-sizing: border-box;
-    z-index: 10;
+    z-index: 2000;
 }
 
 #djtext_toolbar.djtext_toggle {


### PR DESCRIPTION
A higher z-index helps ensure the edit dialog appears over top of the website content. The bootstrap css library, for example, uses z-index values 1000-1100 for navigation toolbars and currently they obscure #djtext_toolbar when positioned in the same place.
