### PR TITLE
accept dashes from language ID in urls

### DIFF
--- a/text/urls.py
+++ b/text/urls.py
@@ -5,6 +5,6 @@ from .views import TextView, TextUpdateView
 
 urlpatterns = patterns(
     '',
-    url(r'^text/(?P<text_slug>\w+)/$', TextView.as_view(), name='text'),
+    url(r'^text/(?P<text_slug>[\w-]+)/$', TextView.as_view(), name='text'),
     url(r'^update_text/(?P<text_id>\d+)/$', TextUpdateView.as_view(), name='update_text'),
 )

--- a/text/urls.py
+++ b/text/urls.py
@@ -1,10 +1,8 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from .views import TextView, TextUpdateView
 
-
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^text/(?P<text_slug>[\w-]+)/$', TextView.as_view(), name='text'),
     url(r'^update_text/(?P<text_id>\d+)/$', TextUpdateView.as_view(), name='update_text'),
-)
+]


### PR DESCRIPTION
urls like `/django_text/text/text_body_en-us/` have a dash in them. Previous regex did not accept it.
